### PR TITLE
fix -- CSRFToken for AJAX Requests

### DIFF
--- a/dPT_server/resources/views/home.blade.php
+++ b/dPT_server/resources/views/home.blade.php
@@ -48,6 +48,11 @@ if(pname != "") {
   console.log("Valore Null");
 }
 
+function csrfSafeMethod(method) {
+  // these HTTP methods do not require CSRF protection
+  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+}
+
 // sarebbe meglio $(function() { ma meno comprensibile per te
 $(document).ready(function() {
     $.get('/api/projects', function (data) {
@@ -59,6 +64,14 @@ $(document).ready(function() {
         projects_list += '</ul>';
         //meglio mettere un id='main-content' oltre a class per identificarlo univocamente;
         $('#main-content').html(projects_list);
+    });
+
+    $.ajaxSetup({
+      beforeSend: function(xhr, settings) {
+        if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
+          xhr.setRequestHeader("X-CSRF-Token", window.Laravel.csrfToken);
+        }
+      }
     });
 });
 </script>

--- a/dPT_server/resources/views/layouts/app.blade.php
+++ b/dPT_server/resources/views/layouts/app.blade.php
@@ -26,28 +26,6 @@
         src="https://code.jquery.com/jquery-3.2.1.js"
         integrity="sha256-DZAnKJ/6XZ9si04Hgrsxu/8s717jcIzLy3oi35EouyE="
         crossorigin="anonymous"></script>
-
-    <script>
-        /*$.ajaxSetup({
-        headers: {
-            'X-CSRF-Token': $('meta[name="csrf-token"]').attr('content')
-              }
-        });*/
-
-        function csrfSafeMethod(method) {
-          // these HTTP methods do not require CSRF protection
-          return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
-        }
-        $.ajaxSetup({
-          beforeSend: function(xhr, settings) {
-            if (!csrfSafeMethod(settings.type) && !this.crossDomain) {
-              xhr.setRequestHeader("X-CSRFToken", $('meta[name="csrf-token"]').attr('content'));
-            }
-          }
-        });
-    </script>
-
-
 </head>
 <body>
     <div id="app">


### PR DESCRIPTION
* Questo token viene passato per essere sicuri che una richiesta HTTP di
  POST/PATCH/PUT venga effettuata dopo aver fatto una GET della pagina
  html di riferimento
* Ho messo la funzione $.ajaxSetup nel body dell'HTML in modo che
  venisse eseguito.
* Migliorata l'identificazione del token in Laravel, preso direttamente
  dall'oggetto JSON window.Laravel e non dal DOM con
  $('meta[name="csrf-token"]').attr('content');